### PR TITLE
fix: read MCTS params per-request instead of mutating shared global (#304)

### DIFF
--- a/optillm/__init__.py
+++ b/optillm/__init__.py
@@ -1,5 +1,5 @@
 # Version information
-__version__ = "0.3.16"
+__version__ = "0.3.17"
 
 import os as _os
 

--- a/optillm/server.py
+++ b/optillm/server.py
@@ -416,8 +416,15 @@ def execute_single_approach(approach, system_prompt, initial_query, client, mode
             # since the full token count is already in the response
             return response, 0
         elif approach == 'mcts':
-            return chat_with_mcts(system_prompt, initial_query, client, model, server_config['mcts_simulations'],
-                                            server_config['mcts_exploration'], server_config['mcts_depth'], request_config, request_id)
+            # Read the MCTS params from the per-request config (falling back to
+            # the server defaults) instead of the shared global server_config.
+            # Reading them off the global races with concurrent requests that
+            # overwrite it between the write in proxy() and this read (issue #304).
+            mcts_config = request_config or {}
+            return chat_with_mcts(system_prompt, initial_query, client, model,
+                                            mcts_config.get('mcts_simulations', server_config['mcts_simulations']),
+                                            mcts_config.get('mcts_exploration', server_config['mcts_exploration']),
+                                            mcts_config.get('mcts_depth', server_config['mcts_depth']), request_config, request_id)
         elif approach == 'bon':
             return  best_of_n_sampling(system_prompt, initial_query, client, model, server_config['best_of_n'], request_config, request_id)
         elif approach == 'moa':
@@ -744,9 +751,14 @@ def proxy():
 
     optillm_approach = data.get('optillm_approach', server_config['approach'])
     logger.debug(data)
-    server_config['mcts_depth'] = data.get('mcts_depth', server_config['mcts_depth'])
-    server_config['mcts_exploration'] = data.get('mcts_exploration', server_config['mcts_exploration'])
-    server_config['mcts_simulations'] = data.get('mcts_simulations', server_config['mcts_simulations'])
+    # MCTS params are resolved per-request in execute_single_approach: any
+    # client-sent mcts_* values are already in request_config (copied from the
+    # request body above) and the server defaults are used as the fallback there.
+    # We deliberately do NOT write them back into the shared global server_config:
+    # concurrent requests would overwrite each other's values between the write
+    # here and the read in execute_single_approach, silently corrupting results
+    # under any threaded WSGI server (and the write also leaked one request's
+    # params into every later request). See issue #304.
 
     system_prompt, initial_query, message_optillm_approach = parse_conversation(messages)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "optillm"
-version = "0.3.16"
+version = "0.3.17"
 description = "An optimizing inference proxy for LLMs."
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/test_approaches.py
+++ b/tests/test_approaches.py
@@ -207,6 +207,165 @@ def test_approaches_handle_bad_responses():
     print("✅ approaches handle bad responses gracefully")
 
 
+def test_mcts_params_are_request_scoped():
+    """MCTS params must be read from the per-request config, not the shared
+    global ``server_config`` (issue #304).
+
+    Before the fix, ``proxy`` wrote the request's ``mcts_*`` params into the
+    module-level ``server_config`` and ``execute_single_approach`` read them
+    back out of it. Under Flask's threaded mode (or gunicorn/uWSGI), two
+    concurrent requests race on that global: request B overwrites request A's
+    params between A's write and A's read, silently corrupting A's MCTS run.
+
+    This pins the fix: a per-request ``mcts_*`` value must flow through to
+    ``chat_with_mcts`` untouched, and the shared global must not be mutated as a
+    side effect of running a request.
+    """
+    import optillm.server as server
+
+    captured = {}
+
+    def fake_chat_with_mcts(system_prompt, initial_query, client, model,
+                            num_simulations, exploration_weight, depth,
+                            request_config=None, request_id=None):
+        captured['num_simulations'] = num_simulations
+        captured['exploration_weight'] = exploration_weight
+        captured['depth'] = depth
+        return "mock mcts response", 0
+
+    original_mcts = server.chat_with_mcts
+    saved_defaults = {k: server.server_config[k]
+                      for k in ('mcts_simulations', 'mcts_exploration', 'mcts_depth')}
+    try:
+        server.chat_with_mcts = fake_chat_with_mcts
+        # Pin the global defaults to values distinct from the per-request ones,
+        # so a read from the global is observably different from a per-request read.
+        server.server_config['mcts_simulations'] = 2
+        server.server_config['mcts_exploration'] = 0.2
+        server.server_config['mcts_depth'] = 1
+
+        # Case 1: a per-request override must reach chat_with_mcts verbatim.
+        per_request = {'mcts_simulations': 99, 'mcts_exploration': 0.9, 'mcts_depth': 7}
+        server.execute_single_approach(
+            'mcts', "You are a helpful assistant.", "What is 2 + 2?",
+            MockClient(), "mock-model",
+            request_config=dict(per_request), request_id="req-304")
+
+        assert captured.get('num_simulations') == 99, (
+            f"expected per-request mcts_simulations=99, got {captured.get('num_simulations')} "
+            "— params were read from the shared global instead of request_config (issue #304)")
+        assert captured.get('exploration_weight') == 0.9, (
+            f"expected per-request mcts_exploration=0.9, got {captured.get('exploration_weight')}")
+        assert captured.get('depth') == 7, (
+            f"expected per-request mcts_depth=7, got {captured.get('depth')}")
+
+        # Running a request must not mutate the shared global — that mutation is
+        # exactly what let concurrent requests corrupt each other.
+        assert server.server_config['mcts_simulations'] == 2, (
+            "execute_single_approach must not write per-request MCTS params back "
+            "into the global server_config (issue #304)")
+
+        # Case 2: with no per-request override (e.g. a user who set --simulations
+        # globally via the CLI), the server defaults must still be used.
+        captured.clear()
+        server.execute_single_approach(
+            'mcts', "You are a helpful assistant.", "What is 2 + 2?",
+            MockClient(), "mock-model",
+            request_config={}, request_id="req-304b")
+
+        assert captured.get('num_simulations') == 2, (
+            f"expected the server-default mcts_simulations=2 when no per-request "
+            f"value is sent, got {captured.get('num_simulations')}")
+        assert captured.get('exploration_weight') == 0.2, (
+            f"expected the server-default mcts_exploration=0.2, got {captured.get('exploration_weight')}")
+        assert captured.get('depth') == 1, (
+            f"expected the server-default mcts_depth=1, got {captured.get('depth')}")
+    finally:
+        server.chat_with_mcts = original_mcts
+        server.server_config.update(saved_defaults)
+
+    print("✅ mcts params are request-scoped (issue #304)")
+
+
+def test_proxy_does_not_mutate_global_mcts_config():
+    """End-to-end guard for the #304 fix at the proxy layer.
+
+    Drives a real request through the Flask ``/v1/chat/completions`` handler with
+    per-request MCTS params and asserts the shared global ``server_config`` is
+    NOT mutated as a side effect (the mutation is what let concurrent requests
+    corrupt each other), while the per-request values still reach ``chat_with_mcts``.
+    """
+    import optillm.server as server
+
+    class _FakeResp:
+        def model_dump(self):
+            return {"choices": [{"index": 0,
+                                 "message": {"role": "assistant", "content": "ok"},
+                                 "finish_reason": "stop"}],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}}
+
+    class _FakeClient:
+        def __init__(self):
+            self.chat = type("_Chat", (), {
+                "completions": type("_Completions", (), {"create": lambda self, **k: _FakeResp()})()
+            })()
+
+    captured = {}
+
+    def fake_chat_with_mcts(system_prompt, initial_query, client, model,
+                            num_simulations, exploration_weight, depth,
+                            request_config=None, request_id=None):
+        captured['num_simulations'] = num_simulations
+        captured['exploration_weight'] = exploration_weight
+        captured['depth'] = depth
+        return "mock mcts response", 5
+
+    original_get_config = server.get_config
+    original_mcts = server.chat_with_mcts
+    saved_defaults = {k: server.server_config[k]
+                      for k in ('mcts_simulations', 'mcts_exploration', 'mcts_depth')}
+    try:
+        server.get_config = lambda: (_FakeClient(), 'optillm')
+        server.chat_with_mcts = fake_chat_with_mcts
+        server.server_config['mcts_simulations'] = 2
+        server.server_config['mcts_exploration'] = 0.2
+        server.server_config['mcts_depth'] = 1
+
+        server.app.config['TESTING'] = True
+        client = server.app.test_client()
+        resp = client.post(
+            '/v1/chat/completions',
+            json={"model": "gpt-4o-mini",
+                  "messages": [{"role": "user", "content": "hello"}],
+                  "optillm_approach": "mcts",
+                  "mcts_simulations": 99, "mcts_exploration": 0.9, "mcts_depth": 7},
+            headers={"Authorization": "Bearer optillm"})
+
+        assert resp.status_code == 200, f"expected 200, got {resp.status_code}: {resp.get_data(as_text=True)[:200]}"
+
+        # Per-request params must have reached the MCTS approach.
+        assert captured.get('num_simulations') == 99, (
+            f"per-request mcts_simulations should reach chat_with_mcts, got {captured.get('num_simulations')}")
+        assert captured.get('depth') == 7, (
+            f"per-request mcts_depth should reach chat_with_mcts, got {captured.get('depth')}")
+
+        # ...but the shared global must be untouched (issue #304). On the buggy
+        # code proxy() wrote these back into server_config, so this would be 99/0.9/7.
+        assert server.server_config['mcts_simulations'] == 2, (
+            f"proxy must not write per-request mcts_simulations into the global "
+            f"server_config, found {server.server_config['mcts_simulations']} (issue #304)")
+        assert server.server_config['mcts_exploration'] == 0.2, (
+            f"proxy leaked mcts_exploration into the global: {server.server_config['mcts_exploration']}")
+        assert server.server_config['mcts_depth'] == 1, (
+            f"proxy leaked mcts_depth into the global: {server.server_config['mcts_depth']}")
+    finally:
+        server.get_config = original_get_config
+        server.chat_with_mcts = original_mcts
+        server.server_config.update(saved_defaults)
+
+    print("✅ proxy does not mutate global mcts config (issue #304)")
+
+
 if __name__ == "__main__":
     print("Running approach tests...")
 
@@ -214,5 +373,7 @@ if __name__ == "__main__":
     test_basic_approach_calls()
     test_approach_parameters()
     test_approaches_handle_bad_responses()
+    test_mcts_params_are_request_scoped()
+    test_proxy_does_not_mutate_global_mcts_config()
 
     print("\nAll tests completed!")


### PR DESCRIPTION
## Summary

Fixes #304 — a race condition where concurrent requests corrupt each other's MCTS parameters through shared global state.

`proxy()` wrote the request's `mcts_depth` / `mcts_exploration` / `mcts_simulations` into the **module-level** `server_config` on every request, and `execute_single_approach()` read them back out of that same global:

```python
# proxy()  (server.py)
server_config['mcts_depth']       = data.get('mcts_depth', server_config['mcts_depth'])
server_config['mcts_exploration'] = data.get('mcts_exploration', server_config['mcts_exploration'])
server_config['mcts_simulations'] = data.get('mcts_simulations', server_config['mcts_simulations'])
...
# execute_single_approach()
return chat_with_mcts(..., server_config['mcts_simulations'],
                           server_config['mcts_exploration'],
                           server_config['mcts_depth'], ...)
```

Under Flask's default threaded mode (or gunicorn / uWSGI / Hypercorn), two concurrent requests race on that global: request B overwrites request A's params between A's write and A's read, so A silently runs MCTS with B's settings. As a secondary effect, a request that sets any `mcts_*` value also **persistently** mutates the global for every later request.

## Fix

Every other request parameter already flows bottom-up through the per-request `request_config` dict. MCTS was the lone leftover pushing into shared mutable state. The fix makes it consistent with the rest:

- `execute_single_approach()` now reads the MCTS params from `request_config` (with the `server_config` defaults as fallback) instead of the global.
- `proxy()` no longer writes them back into `server_config`.

Because a client-sent `mcts_*` value is already copied into `request_config` from the request body, and the fallback resolves to the server/CLI defaults otherwise, behaviour is unchanged for every caller — including the "user set `--simulations` globally and never sends a per-request override" path — while the shared global is now read-only per request, so there is nothing left to race on.

The change is intentionally scoped to `mcts`. `bon` (`best_of_n`) and `rstar` read their params from `server_config` too, but they are never written back per-request, so they have no write-then-read race — #304 is specifically the MCTS write-back.

## Testing

Added regression tests to `tests/test_approaches.py` (runs in the existing `unit-tests` CI job):

- `test_mcts_params_are_request_scoped` — a per-request `mcts_*` value reaches `chat_with_mcts`; with no per-request value the server default is used (CLI-default path); the global is not mutated.
- `test_proxy_does_not_mutate_global_mcts_config` — drives a real request through the Flask `/v1/chat/completions` handler with per-request MCTS params and asserts the shared global `server_config` is left untouched while the per-request values still reach the approach.

Both tests fail on `main` (the per-request read returns the stale global default; the proxy mutates the global) and pass with this change.
