### PR TITLE
Cap transformers <5.13 to keep mlx-lm importable on macOS (v0.3.19)

### DIFF
--- a/optillm/__init__.py
+++ b/optillm/__init__.py
@@ -1,5 +1,5 @@
 # Version information
-__version__ = "0.3.18"
+__version__ = "0.3.19"
 
 import os as _os
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "optillm"
-version = "0.3.18"
+version = "0.3.19"
 description = "An optimizing inference proxy for LLMs."
 readme = "README.md"
 license = "Apache-2.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,11 @@ z3-solver<=4.15.4.0
 aiohttp
 flask
 torch
-transformers>=5.0.0
+# Cap below 5.13: transformers 5.13.0 tightened AutoTokenizer.register() to require
+# a class, which breaks mlx-lm (it registers a tokenizer by string name). Lift the
+# cap once mlx-lm ships a transformers-5.13-compatible release. See mlx_lm
+# tokenizer_utils.register("NewlineTokenizer", ...).
+transformers>=5.0.0,<5.13.0
 azure.identity
 tiktoken
 scikit-learn


### PR DESCRIPTION
## Problem

On Apple silicon, `import optillm` crashes with:

```
AttributeError: 'str' object has no attribute '__module__'
  at transformers/models/auto/auto_factory.py:680 in register()
```

**Root cause:** transformers **5.13.0** tightened `AutoTokenizer.register()` to require a class (it does `key.__module__`). `mlx-lm` 0.31.3 (latest) registers a custom tokenizer by **string** name:

```python
# mlx_lm/tokenizer_utils.py:505
AutoTokenizer.register("NewlineTokenizer", fast_tokenizer_class=NewlineTokenizer)
```

transformers ≤5.12.1 tolerated the string; 5.13.0 raises. Since optillm declares `transformers>=5.0.0` with no ceiling, a fresh install pulls 5.13.0.

**macOS-only:** optillm installs `mlx-lm` only under `platform_machine=="arm64" and sys_platform=="darwin"`. Linux CI never installs mlx-lm, so it silently ran 5.13.0 fine — which is why CI stayed green while local Mac installs broke.

## Fix

Pin `transformers>=5.0.0,<5.13.0` (resolves to 5.12.1). Verified: mlx-lm then imports cleanly.

The transformers 5.13.0 HF path itself is fine — I confirmed dhara-250m loads and generates on 5.13.0. The incompatibility is purely mlx-lm's; lift the cap once mlx-lm ships a 5.13-compatible release.

## Testing

- Reproduced the crash with `transformers==5.13.0` + `mlx-lm` in a clean venv.
- Verified `transformers>=5.0.0,<5.13.0` resolves to 5.12.1 and `import mlx_lm` succeeds.
- Confirmed the dhara HF path (tokenizer + generate) works on both 5.12.1 and 5.13.0.