### PR TITLE
Fix broken PyPI wheel deps: add math-verify, cap transformers <5.13 (v0.3.21)

### DIFF
--- a/optillm/__init__.py
+++ b/optillm/__init__.py
@@ -1,5 +1,5 @@
 # Version information
-__version__ = "0.3.20"
+__version__ = "0.3.21"
 
 import os as _os
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "optillm"
-version = "0.3.20"
+version = "0.3.21"
 description = "An optimizing inference proxy for LLMs."
 readme = "README.md"
 license = "Apache-2.0"
@@ -24,7 +24,9 @@ dependencies = [
     "aiohttp",
     "flask",
     "torch",
-    "transformers",
+    # Cap below 5.13: transformers 5.13.0 tightened AutoTokenizer.register() to
+    # require a class, which breaks mlx-lm (registers a tokenizer by string name).
+    "transformers>=5.0.0,<5.13.0",
     "azure-identity",
     "tiktoken",
     "scikit-learn",
@@ -44,11 +46,12 @@ dependencies = [
     "gradio<5.16.0",
     "spacy>=3.7.0",
     "cerebras_cloud_sdk",
-    "outlines[transformers]",
+    "outlines[transformers]>=1.2.3",
     "sentencepiece",
     "mcp",
     "adaptive-classifier",
     "datasets",
+    "math-verify",
     "PyYAML",
     "selenium",
     "webdriver-manager",


### PR DESCRIPTION
## Problem

`pip install optillm` (from PyPI) shipped a **broken** package: `import optillm` fails with `ModuleNotFoundError: No module named 'math_verify'`, so the server won't even start.

Root cause: the published wheel is built from **`pyproject.toml` `[project.dependencies]`**, which had drifted from `requirements.txt`:

- **`math-verify` was missing entirely** — `optillm/cepo/cepo.py` imports `math_verify` at import time, so importing optillm crashes.
- **`transformers` was unpinned** — the `<5.13.0` cap added in 0.3.19 only went into `requirements.txt`, so PyPI installs pulled transformers 5.13.0 and broke mlx-lm on Apple silicon (the exact issue 0.3.19 was meant to fix).

This was masked in CI because the dev install uses `requirements.txt` (which had the deps), and the integration job's server-start step swallows startup errors with `|| echo`.

## Fix

Sync the runtime deps into `pyproject.toml`:
- add `math-verify`
- `transformers>=5.0.0,<5.13.0`
- `outlines[transformers]>=1.2.3`

## Verification

Built the wheel and installed it into a **clean venv** (only its declared deps), then imported optillm — no `ModuleNotFoundError`, and transformers resolves to 5.12.x. (Wheel metadata now lists `Requires-Dist: math-verify` and `transformers<5.13.0,>=5.0.0`.)