### PR TITLE
Fix autothink and thinkdeeper for transformers>=5

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,8 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/algorithmicsuperintelligence/optillm/stargazers"><img src="https://img.shields.io/github/stars/algorithmicsuperintelligence/optillm?style=social" alt="GitHub stars"></a>
   <a href="https://pypi.org/project/optillm/"><img src="https://img.shields.io/pypi/v/optillm" alt="PyPI version"></a>
-  <a href="https://pypi.org/project/optillm/"><img src="https://img.shields.io/pypi/dm/optillm" alt="PyPI downloads"></a>
+  <a href="https://pepy.tech/projects/optillm"><img src="https://static.pepy.tech/personalized-badge/optillm?period=monthly&units=INTERNATIONAL_SYSTEM&left_color=BLACK&right_color=GREEN&left_text=downloads/month" alt="PyPI Downloads"></a>
   <a href="https://github.com/algorithmicsuperintelligence/optillm/blob/main/LICENSE"><img src="https://img.shields.io/github/license/algorithmicsuperintelligence/optillm" alt="License"></a>
 </p>
 

--- a/optillm/__init__.py
+++ b/optillm/__init__.py
@@ -1,5 +1,5 @@
 # Version information
-__version__ = "0.3.21"
+__version__ = "0.3.22"
 
 import os as _os
 

--- a/optillm/autothink/processor.py
+++ b/optillm/autothink/processor.py
@@ -243,7 +243,8 @@ class AutoThinkProcessor:
                 thinking_messages,
                 continue_final_message=True,
                 return_tensors="pt"
-            ).to(self.model.device)
+            ).input_ids
+            tokens.to(self.model.device)
             
             # Reset and update token history in steering hooks
             if self.steering_hooks:

--- a/optillm/autothink/processor.py
+++ b/optillm/autothink/processor.py
@@ -243,8 +243,7 @@ class AutoThinkProcessor:
                 thinking_messages,
                 continue_final_message=True,
                 return_tensors="pt"
-            ).input_ids
-            tokens.to(self.model.device)
+            ).input_ids.to(self.model.device)
             
             # Reset and update token history in steering hooks
             if self.steering_hooks:

--- a/optillm/deepconf/processor.py
+++ b/optillm/deepconf/processor.py
@@ -108,7 +108,7 @@ class DeepConfProcessor:
             messages,
             return_tensors="pt",
             add_generation_prompt=True
-        ).to(self.model.device)
+        ).input_ids.to(self.model.device)
         
         # Initialize generation state
         kv_cache = DynamicCache()

--- a/optillm/thinkdeeper.py
+++ b/optillm/thinkdeeper.py
@@ -77,8 +77,8 @@ class ThinkDeeperProcessor:
             messages,
             continue_final_message=True,
             return_tensors="pt"
-        )
-        tokens = tokens.to(self.model.device)
+        ).input_ids
+        tokens.to(self.model.device)
 
         kv = DynamicCache()
         n_thinking_tokens = 0

--- a/optillm/thinkdeeper.py
+++ b/optillm/thinkdeeper.py
@@ -77,8 +77,7 @@ class ThinkDeeperProcessor:
             messages,
             continue_final_message=True,
             return_tensors="pt"
-        ).input_ids
-        tokens.to(self.model.device)
+        ).input_ids.to(self.model.device)
 
         kv = DynamicCache()
         n_thinking_tokens = 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "optillm"
-version = "0.3.21"
+version = "0.3.22"
 description = "An optimizing inference proxy for LLMs."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Since version 5 of the `transformers` library, method `apply_chat_template` returns a `BatchEncoding` object, which wraps the output tensor in a `dict`-like object: https://github.com/huggingface/transformers/blob/7ea2320c76117e6742364808a666ef6f2fb40a67/MIGRATION_GUIDE_V5.md#4-apply_chat_template-returns-batchencoding

The code in `autothink` and `thinkdeeper` did not account for this, which made the following code throw:
```python
import torch
from optillm.thinkdeeper import thinkdeeper_decode
from transformers import AutoModelForCausalLM, AutoTokenizer

model_id = "Qwen/Qwen2.5-0.5B-Instruct"
model = AutoModelForCausalLM.from_pretrained(model_id)
tokenizer = AutoTokenizer.from_pretrained(model_id)

messages = [
    {
        "role": "user",
        "content": "In a dance class of 20 students, 20% enrolled in contemporary dance, 25% of the remaining enrolled in jazz dance, and the rest enrolled in hip-hop dance. What percentage of the entire students enrolled in hip-hop dance?",
    },
]

thinkdeeper_decode(
    model,
    tokenizer,
    messages,
    {
        "do_sample": True,
        "temperature": 0.1,
        "max_new_tokens": 1024,
    }
)
```

This PR fixes this issue by noticing that, since OptiLLM explicitly depends on `transformers` at version 5 and above (https://github.com/algorithmicsuperintelligence/optillm/blob/c2588583aa2256b78a6a52cc127fb1a5b6d4eed9/pyproject.toml#L29), it's safe to unwrap the `BatchEncoding` object and query its `input_ids` property.