### PR TITLE
fix(readurls): block SSRF destinations

### DIFF
--- a/optillm/plugins/readurls_plugin.py
+++ b/optillm/plugins/readurls_plugin.py
@@ -1,12 +1,65 @@
+import ipaddress
 import re
+import socket
 from typing import Tuple, List, Optional
 import requests
+from requests.adapters import HTTPAdapter
 import os
 from bs4 import BeautifulSoup
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 from optillm import __version__, server_config
 
 SLUG = "readurls"
+
+
+def resolve_public_ip(url: str) -> Optional[str]:
+    """Resolve *url* once and return a pinned public IP address, if safe."""
+    parsed_url = urlparse(url)
+    if parsed_url.scheme not in {"http", "https"} or not parsed_url.hostname:
+        return None
+
+    try:
+        addresses = socket.getaddrinfo(
+            parsed_url.hostname, None, type=socket.SOCK_STREAM
+        )
+    except (socket.gaierror, ValueError):
+        return None
+
+    try:
+        ip_addresses = [ipaddress.ip_address(address[4][0]) for address in addresses]
+    except ValueError:
+        return None
+
+    if not ip_addresses or not all(address.is_global for address in ip_addresses):
+        return None
+    return str(ip_addresses[0])
+
+
+class PinnedIPAdapter(HTTPAdapter):
+    """Connect to a validated IP while retaining the original HTTPS hostname."""
+
+    def __init__(self, verified_ip: str, hostname: str):
+        self.verified_ip = verified_ip
+        self.hostname = hostname
+        super().__init__()
+
+    def get_connection_with_tls_context(self, request, verify, proxies=None, cert=None):
+        host_params, pool_kwargs = self.build_connection_pool_key_attributes(
+            request, verify, cert
+        )
+        host_params["host"] = self.verified_ip
+        if host_params["scheme"] == "https":
+            pool_kwargs["assert_hostname"] = self.hostname
+            pool_kwargs["server_hostname"] = self.hostname
+        request.headers["Host"] = urlparse(request.url).netloc
+        return self.poolmanager.connection_from_host(
+            **host_params, pool_kwargs=pool_kwargs
+        )
+
+
+def is_safe_url(url: str) -> bool:
+    return resolve_public_ip(url) is not None
+
 
 def extract_urls(text: str) -> List[str]:
     # Updated regex pattern to be more precise
@@ -44,7 +97,36 @@ def fetch_webpage_content(url: str, max_length: int = 100000, verify_ssl: Option
         else:
             verify = True
 
-        response = requests.get(url, headers=headers, timeout=10, verify=verify)
+        current_url = url
+        for _ in range(5):
+            verified_ip = resolve_public_ip(current_url)
+            parsed_url = urlparse(current_url)
+            if not verified_ip or not parsed_url.hostname:
+                return "Error fetching content: blocked unsafe URL"
+
+            session = requests.Session()
+            session.trust_env = False
+            session.mount(
+                f"{parsed_url.scheme}://",
+                PinnedIPAdapter(verified_ip, parsed_url.hostname),
+            )
+            response = session.get(
+                current_url,
+                headers=headers,
+                timeout=10,
+                verify=verify,
+                allow_redirects=False,
+            )
+            if not response.is_redirect:
+                break
+
+            location = response.headers.get("Location")
+            if not location:
+                return "Error fetching content: redirect missing Location header"
+            current_url = urljoin(current_url, location)
+        else:
+            return "Error fetching content: too many redirects"
+
         response.raise_for_status()
         
         # Make a soup 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "cerebras_cloud_sdk",
     "outlines[transformers]>=1.2.3",
     "sentencepiece",
-    "mcp",
+    "mcp<2",
     "adaptive-classifier",
     "datasets",
     "math-verify",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "scikit-learn",
     "litellm",
     "google-cloud-aiplatform",
-    "requests",
+    "requests>=2.32.2",
     "beautifulsoup4",
     "lxml",
     "presidio_analyzer",

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ tiktoken
 scikit-learn
 litellm
 google-cloud-aiplatform
-requests
+requests>=2.32.2
 beautifulsoup4
 lxml
 selenium

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ outlines[transformers]>=1.2.3
 sentencepiece
 adaptive-classifier
 datasets
-mcp
+mcp<2
 # MLX support for Apple Silicon optimization
 mlx-lm>=0.24.0; platform_machine=="arm64" and sys_platform=="darwin"
 math-verify

--- a/tests/test_readurls_ssrf.py
+++ b/tests/test_readurls_ssrf.py
@@ -1,0 +1,60 @@
+import socket
+import unittest
+from unittest.mock import ANY, MagicMock, patch
+
+from optillm.plugins.readurls_plugin import fetch_webpage_content, is_safe_url
+
+
+class TestReadUrlsSSRFProtection(unittest.TestCase):
+    @patch("optillm.plugins.readurls_plugin.requests.Session")
+    @patch("optillm.plugins.readurls_plugin.socket.getaddrinfo")
+    def test_does_not_fetch_loopback_url(self, mock_getaddrinfo, mock_session):
+        mock_getaddrinfo.return_value = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 0))
+        ]
+
+        result = fetch_webpage_content("http://localhost:8080/admin")
+
+        self.assertIn("blocked", result.lower())
+        mock_session.assert_not_called()
+
+    @patch("optillm.plugins.readurls_plugin.requests.Session")
+    @patch("optillm.plugins.readurls_plugin.socket.getaddrinfo")
+    def test_blocks_redirect_to_non_public_address(self, mock_getaddrinfo, mock_session):
+        mock_getaddrinfo.side_effect = [
+            [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))],
+            [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 0))],
+        ]
+        redirect_response = MagicMock()
+        redirect_response.is_redirect = True
+        redirect_response.headers = {"Location": "http://localhost/admin"}
+        mock_session.return_value.get.return_value = redirect_response
+
+        result = fetch_webpage_content("https://example.com")
+
+        self.assertIn("blocked", result.lower())
+        mock_session.return_value.get.assert_called_once_with(
+            "https://example.com", headers=ANY, timeout=10,
+            verify=True, allow_redirects=False
+        )
+
+    @patch("optillm.plugins.readurls_plugin.socket.getaddrinfo")
+    def test_rejects_host_with_any_non_public_address(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0)),
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", 0)),
+        ]
+
+        self.assertFalse(is_safe_url("https://example.com"))
+
+    @patch("optillm.plugins.readurls_plugin.socket.getaddrinfo")
+    def test_allows_host_with_only_public_addresses(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0))
+        ]
+
+        self.assertTrue(is_safe_url("https://example.com"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ssl_config.py
+++ b/tests/test_ssl_config.py
@@ -234,7 +234,7 @@ class TestPluginSSLConfiguration(unittest.TestCase):
         server_config.clear()
         server_config.update(self.original_config)
 
-    @patch('optillm.plugins.readurls_plugin.requests.get')
+    @patch('optillm.plugins.readurls_plugin.requests.Session')
     def test_readurls_plugin_ssl_verify_disabled(self, mock_requests_get):
         """Test readurls plugin respects SSL verification disabled."""
         from optillm.plugins.readurls_plugin import fetch_webpage_content
@@ -247,18 +247,18 @@ class TestPluginSSLConfiguration(unittest.TestCase):
         mock_response = MagicMock()
         mock_response.content = b'<html><body><p>Test content</p></body></html>'
         mock_response.raise_for_status = MagicMock()
-        mock_requests_get.return_value = mock_response
+        mock_requests_get.return_value.get.return_value = mock_response
 
         # Fetch webpage
         fetch_webpage_content('https://example.com')
 
         # Verify requests.get was called with verify=False
-        mock_requests_get.assert_called_once()
-        call_kwargs = mock_requests_get.call_args[1]
+        mock_requests_get.return_value.get.assert_called_once()
+        call_kwargs = mock_requests_get.return_value.get.call_args[1]
         self.assertIn('verify', call_kwargs)
         self.assertFalse(call_kwargs['verify'])
 
-    @patch('optillm.plugins.readurls_plugin.requests.get')
+    @patch('optillm.plugins.readurls_plugin.requests.Session')
     def test_readurls_plugin_ssl_verify_enabled(self, mock_requests_get):
         """Test readurls plugin respects SSL verification enabled."""
         from optillm.plugins.readurls_plugin import fetch_webpage_content
@@ -271,18 +271,18 @@ class TestPluginSSLConfiguration(unittest.TestCase):
         mock_response = MagicMock()
         mock_response.content = b'<html><body><p>Test content</p></body></html>'
         mock_response.raise_for_status = MagicMock()
-        mock_requests_get.return_value = mock_response
+        mock_requests_get.return_value.get.return_value = mock_response
 
         # Fetch webpage
         fetch_webpage_content('https://example.com')
 
         # Verify requests.get was called with verify=True
-        mock_requests_get.assert_called_once()
-        call_kwargs = mock_requests_get.call_args[1]
+        mock_requests_get.return_value.get.assert_called_once()
+        call_kwargs = mock_requests_get.return_value.get.call_args[1]
         self.assertIn('verify', call_kwargs)
         self.assertTrue(call_kwargs['verify'])
 
-    @patch('optillm.plugins.readurls_plugin.requests.get')
+    @patch('optillm.plugins.readurls_plugin.requests.Session')
     def test_readurls_plugin_custom_cert_path(self, mock_requests_get):
         """Test readurls plugin uses custom certificate path."""
         from optillm.plugins.readurls_plugin import fetch_webpage_content
@@ -296,14 +296,14 @@ class TestPluginSSLConfiguration(unittest.TestCase):
         mock_response = MagicMock()
         mock_response.content = b'<html><body><p>Test content</p></body></html>'
         mock_response.raise_for_status = MagicMock()
-        mock_requests_get.return_value = mock_response
+        mock_requests_get.return_value.get.return_value = mock_response
 
         # Fetch webpage
         fetch_webpage_content('https://example.com')
 
         # Verify requests.get was called with custom cert path
-        mock_requests_get.assert_called_once()
-        call_kwargs = mock_requests_get.call_args[1]
+        mock_requests_get.return_value.get.assert_called_once()
+        call_kwargs = mock_requests_get.return_value.get.call_args[1]
         self.assertIn('verify', call_kwargs)
         self.assertEqual(call_kwargs['verify'], test_cert_path)
 


### PR DESCRIPTION
## Summary
- Resolve each readurls destination and reject non-public address ranges.
- Pin each HTTP connection to the validated IP to prevent DNS rebinding.
- Validate every redirect hop before requesting it.

## Tests
- `OPTILLM_API_KEY=optillm .venv/bin/python tests/test_ci_quick.py`
- `.venv/bin/python -m pytest tests/test_readurls_ssrf.py tests/test_ssl_config.py -q`

Fixes #323